### PR TITLE
add host to enable RSS

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -27,6 +27,7 @@ module.exports = function (environment) {
       title: "Aidan Bennett",
       description: "This is Aidan's Blog built with Ember",
       coverImage: "/images/blog-cover.jpg",
+      host: "https://blog.aidanbennett.me",
 
       navigation: [
         //  {


### PR DESCRIPTION
You might notice a warning when you build the site about adding `host` to enable RSS. This is what this PR is doing 🎉 

Here is more info if you're interested in reading more about this https://github.com/empress/empress-blog/#configuring-your-host--enabling-rss